### PR TITLE
Correctly serialize obj w/ multiple appearances

### DIFF
--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -200,23 +200,13 @@ module JSONAPI
               if resource
                 id = resource.id
                 type = relationship.type_for_source(source)
-                relationships_only = already_serialized?(type, id)
-                if include_linkage && !relationships_only
-                  add_included_object(id, object_hash(resource, ia))
-                elsif include_linked_children || relationships_only
-                  relationship_data(resource, ia)
-                end
+                add_included_object(id, object_hash(resource, ia))
               end
             elsif relationship.is_a?(JSONAPI::Relationship::ToMany)
               resources = source.public_send(name)
               resources.each do |resource|
                 id = resource.id
-                relationships_only = already_serialized?(type, id)
-                if include_linkage && !relationships_only
-                  add_included_object(id, object_hash(resource, ia))
-                elsif include_linked_children || relationships_only
-                  relationship_data(resource, ia)
-                end
+                add_included_object(id, object_hash(resource, ia))
               end
             end
           end
@@ -328,7 +318,7 @@ module JSONAPI
       @included_objects[type] = {} unless @included_objects.key?(type)
 
       if already_serialized?(type, id)
-        @included_objects[type][id][:object_hash].merge!(object_hash)
+        @included_objects[type][id][:object_hash].deep_merge!(object_hash)
         set_primary(type, id) if primary
       else
         @included_objects[type].store(id, primary: primary, object_hash: object_hash)


### PR DESCRIPTION
If an object appears multiple times in the object graph, it's relationships should be serialized according to the include list.

Example
Include List
 nodes,nodes.child_nodes,nodes.parent_nodes

Node (id: 1, parent_node: null, child_nodes: [2])
Node (id: 2, parent_node: 1, child_nodes: [1])

Current order of operations
Node 1 Loaded
Node 2 Loaded via node1.child_nodes
Node 2  Serialized 
Node 2 Loaded (different instance than above)
Node 1 Loaded via node2.parent_node
Node 2 not serialized, because it already was, relationship to parent_node lost

The fix is to always add_included_object with related data and to deep_merge serialized data.  This results in extra object_hashes being generated, but allows the resulting data to be correct.
